### PR TITLE
Display form warning only when non-empty

### DIFF
--- a/gridt/src/app/movements/add-movement/add-movement.page.html
+++ b/gridt/src/app/movements/add-movement/add-movement.page.html
@@ -24,7 +24,9 @@
         </ion-col>
       </ion-row>
       <ion-row *ngIf="
-        !form.get('name').valid && form.get('name').touched
+        !form.get('name').valid && 
+        form.get('name').touched &&
+        form.get('name').value != ''
       ">
         <ion-col size-sm="6" offset-sm="3">
           <p>Name must be between 4 and 50 characters.</p>
@@ -39,7 +41,9 @@
         </ion-col>
       </ion-row>
       <ion-row *ngIf="
-        !form.get('short_description').valid && form.get('short_description').touched
+        !form.get('short_description').valid && 
+        form.get('short_description').touched &&
+        form.get('short_description').value != ''
       ">
         <ion-col size-sm="6" offset-sm="3">
           <p>Short description must be between 10 and 100 characters.</p>


### PR DESCRIPTION
I made a little change that makes the create-new-movement form a bit less aggressive in warning that the form is incorrectly filled. (I.e.: if you only click it and go to another part of the form, the warning doesn't display.)