### PR TITLE
Issue #106 Add safety warning in register

### DIFF
--- a/gridt/src/app/login/register/register.page.spec.ts
+++ b/gridt/src/app/login/register/register.page.spec.ts
@@ -1,16 +1,18 @@
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-import { HttpClientModule } from '@angular/common/http';
-import { FormsModule } from '@angular/forms';
-import { IonicModule } from '@ionic/angular';
+import { CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+import { RouterTestingModule } from "@angular/router/testing";
+import { HttpClientModule } from "@angular/common/http";
+import { FormsModule } from "@angular/forms";
+import { IonicModule, AlertController } from "@ionic/angular";
 
-import { RegisterPage } from './register.page';
+import { RegisterPage } from "./register.page";
 
-describe('RegisterPage', () => {
+describe("RegisterPage", () => {
+  //testing suite, (de pagina te testen)
   let component: RegisterPage;
   let fixture: ComponentFixture<RegisterPage>;
-
+  let alertSpy: AlertController = jasmine.createSpyObj("alertSpy", ["create", "dismiss"]);
+//worden elke test opnieuw geladen
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ RegisterPage ],
@@ -21,6 +23,10 @@ describe('RegisterPage', () => {
         FormsModule,
         IonicModule,
       ],
+      providers: [{
+        provide: AlertController,
+        useValue: alertSpy
+      }]
     })
     .compileComponents();
   }));
@@ -31,7 +37,16 @@ describe('RegisterPage', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should alert the user when opening the page", () => {
+    expect(alertSpy.create).toHaveBeenCalled();
+  });
+
+  it("should dismiss the alert when leaving the page", () => {
+    component.ngOnDestroy();
+    expect(alertSpy.dismiss).toHaveBeenCalled();
   });
 });

--- a/gridt/src/app/login/register/register.page.ts
+++ b/gridt/src/app/login/register/register.page.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import { LoadingController, AlertController } from '@ionic/angular';
 import { NgForm } from '@angular/forms';
@@ -9,7 +9,7 @@ import { AuthService } from '../../core/auth.service';
   templateUrl: './register.page.html',
   styleUrls: ['./register.page.scss'],
 })
-export class RegisterPage implements OnInit {
+export class RegisterPage implements OnInit, OnDestroy {
 
 
   constructor(
@@ -17,17 +17,20 @@ export class RegisterPage implements OnInit {
     private loadingCtrl: LoadingController,
     private alertCtrl: AlertController,
     private auth: AuthService,
-    private alertController: AlertController
     ) { }
 
   ngOnInit() {
     this.showSafetyAlert();
   }
+
+  ngOnDestroy() {
+    this.alertCtrl.dismiss();
+  }
   /*
   * Creates warning for unique password
   */
   private async showSafetyAlert() {
-    const alert = await this.alertController.create({
+    const alert = await this.alertCtrl.create({
       header: "Warning",
       subHeader: "Password Safety",
       message: "This app is in Alpha and therefore we cannot guarantee the safety of your data. Please keep this in mind when picking your password. We recommend you pick a password you do not use anywhere else.",

--- a/gridt/src/app/login/register/register.page.ts
+++ b/gridt/src/app/login/register/register.page.ts
@@ -17,9 +17,25 @@ export class RegisterPage implements OnInit {
     private loadingCtrl: LoadingController,
     private alertCtrl: AlertController,
     private auth: AuthService,
+    private alertController: AlertController
     ) { }
 
   ngOnInit() {
+    this.showSafetyAlert();
+  }
+  /*
+  * Creates warning for unique password
+  */
+  private async showSafetyAlert() {
+    const alert = await this.alertController.create({
+      header: "Warning",
+      subHeader: "Password Safety",
+      message: "This app is in Alpha and therefore we cannot guarantee the safety of your data. Please keep this in mind when picking your password. We recommend you pick a password you do not use anywhere else.",
+      buttons: ["Accept"],
+      backdropDismiss: false
+    });
+
+    await alert.present();
   }
 
   /*


### PR DESCRIPTION

Added:
-Warning added when entering the register page #106
-Alert tests on entering and on leaving
-Added dismiss in ngOnDestroy()

This is a short term change that should be removed when we feel more confident in our security and have implemented a better terms of service