### PR TITLE
Change add movement button

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <img src="https://img.shields.io/website?url=https%3A%2F%2Fapp.gridt.org" alt="website">
   </a>
   <a href="https://github.com/GridtNetwork/gridt-client/actions?query=workflow%3ACI">
-    <img src="https://github.com/GridtNetwork/gridt-client/workflows/CI/badge.svg?branch=main" alt="Build Status">
+    <img src="https://github.com/GridtNetwork/gridt-client/workflows/CI/badge.svg" alt="Build Status">
   </a>
   <a href="https://github.com/GridtNetwork/gridt-client/actions?query=workflow%3ACI">
     <img src="https://img.shields.io/github/last-commit/GridtNetwork/gridt-client" alt="Build Status">

--- a/gridt/src/app/movements/movements.page.html
+++ b/gridt/src/app/movements/movements.page.html
@@ -71,3 +71,9 @@
 </ion-list>
 
 </ion-content>
+
+<ion-fab vertical="bottom" horizontal="end" slot="fixed" style="padding-right: 0.5rem;">
+  <ion-fab-button color="primary" routerLink="/add">
+    <ion-icon name="add"></ion-icon>
+  </ion-fab-button>
+</ion-fab>

--- a/gridt/src/app/movements/movements.page.html
+++ b/gridt/src/app/movements/movements.page.html
@@ -1,79 +1,75 @@
 <ion-header>
-  <ion-toolbar>
+  <ion-toolbar >
     <ion-buttons slot="start">
       <ion-menu-button></ion-menu-button>
     </ion-buttons>
-    <ion-title>Movements </ion-title>
+    <ion-title>
+      Movements
+    </ion-title>
+    <ion-buttons slot="primary">
+      <ion-button routerLink="/add">
+        <ion-icon name="add" slot="icon-only"></ion-icon>
+      </ion-button>
+    </ion-buttons>
   </ion-toolbar>
 </ion-header>
+
 
 <ion-content padding>
   <!-- First an explicit search bar -->
   <ion-row>
     <ion-col size-md="6" offset-md="3">
       <ion-toolbar>
-        <ion-searchbar
-          showCancelButton="focus"
+        <ion-searchbar 
+          showCancelButton="focus" 
           [(ngModel)]="searchText"
         ></ion-searchbar>
       </ion-toolbar>
     </ion-col>
   </ion-row>
-  <!-- Then print a list of all the movements -->
-  <ion-list>
-    <ion-grid *ngIf="!(movements$ | async)">
-      <ion-row>
-        <ion-col size="12" size-sm="8" offset-sm="2" text-center>
-          <p>There are no movements right now, please come back later!</p>
-        </ion-col>
-      </ion-row>
-    </ion-grid>
+<!-- Then print a list of all the movements -->
+<ion-list>
+    <ion-grid
+      *ngIf="!(movements$ | async)">
+    <ion-row>
+      <ion-col size="12" size-sm="8" offset-sm="2" text-center>
+        <p>There are no movements  right now, please come back later!</p>
+      </ion-col>
+    </ion-row>
+  </ion-grid>
     <ion-grid *ngIf="movements$ | async">
-      <!-- Create a list item for each search result.
+
+  <!-- Create a list item for each search result.
     Here I had to guess the routerLink, but that can be changed later.
     async allows the results to change by making a new search.
   -->
       <ion-row>
         <ion-col size-md="6" offset-md="3">
-          <ion-item
-            *ngFor="let movement of movements$ | async | movementFilter: searchText"
-            [routerLink]="['/', 'movements', movement.name]"
-            detail
-            button
+          <ion-item *ngFor="let movement of movements$ | async | movementFilter: searchText"
+            [routerLink]="['/', 'movements', movement.name]" 
+            detail button
           >
             <!-- Right now, this just shows every single movement -->
             <!-- Display the title on the left with icon if user is subscribed-->
             <ion-label text-wrap>
               <h3>
-                {{ movement.name }}
-                <ion-icon
-                  *ngIf="movement.subscribed"
-                  name="people-sharp"
-                ></ion-icon>
+                {{ movement.name }} 
+                <ion-icon *ngIf="movement.subscribed" name="people-sharp"></ion-icon> 
               </h3>
-              <p class="shortdescription">{{ movement.short_description }}</p>
+              <p class="shortdescription">{{ movement.short_description }}</p> 
             </ion-label>
 
-            <!-- Display the interval (like, weekly, monthly etc.) on the right -->
-            <ion-label slot="end"> {{ movement.interval }} </ion-label>
+             <!-- Display the interval (like, weekly, monthly etc.) on the right -->
+            <ion-label slot="end"> 
+              {{ movement.interval }}
+            </ion-label>
           </ion-item>
-        </ion-col>
+         </ion-col>
       </ion-row>
     </ion-grid>
-  </ion-list>
-  <!-- Custom floating button for adding movements -->
-  <ion-fab vertical="bottom" horizontal="end" slot="fixed">
-    <ion-fab-button class="custom" color="primary" routerLink="/add">
-      Add Movement <ion-icon name="add"></ion-icon>
-    </ion-fab-button>
-  </ion-fab>
 
-  <!-- Regular floating button
-    <ion-fab vertical="bottom" horizontal="end" slot="fixed">
-      <ion-fab-button color="primary" routerLink="/add">
-        <ion-icon name="add"></ion-icon>
-      </ion-fab-button>
-    </ion-fab> -->
+</ion-list>
+
 </ion-content>
 
 <ion-fab vertical="bottom" horizontal="end" slot="fixed" style="padding-right: 0.5rem;">

--- a/gridt/src/app/movements/movements.page.scss
+++ b/gridt/src/app/movements/movements.page.scss
@@ -1,8 +1,3 @@
 .shortdescription {
   font-size: 12px;
 }
-
-.custom {
-  width: 10rem;
-  --border-radius: 30px;
-}


### PR DESCRIPTION
I've decided to remove the button from the top menu and implement it in a floating action button. It scales well on mobile, even on smaller screens, and adds a bit of color to the otherwise spartan UI. Desktops don't adapt, however, and thus another solution should be found.

While typing this, I realized the original issue of button ambiguity hasn't been addressed. I tweaked the floating button to include the description of the action. I've included both, with the original one commented out.