### PR TITLE
Added FAB for the Add Movement

### DIFF
--- a/gridt/src/app/movements/movements.page.html
+++ b/gridt/src/app/movements/movements.page.html
@@ -6,11 +6,6 @@
     <ion-title>
       Movements
     </ion-title>
-    <ion-buttons slot="primary">
-      <ion-button routerLink="/add">
-        <ion-icon name="add" slot="icon-only"></ion-icon>
-      </ion-button>
-    </ion-buttons>
   </ion-toolbar>
 </ion-header>
 

--- a/gridt/src/app/movements/movements.page.html
+++ b/gridt/src/app/movements/movements.page.html
@@ -71,3 +71,9 @@
 </ion-list>
 
 </ion-content>
+
+<ion-fab vertical="bottom" horizontal="end" slot="fixed" style="padding-right: 0.5rem;">
+  <ion-fab-button color="primary" routerLink="/add">
+    <ion-icon name="add"></ion-icon>
+  </ion-fab-button>
+</ion-fab> 


### PR DESCRIPTION
This commit address issue #114. The Add Movement button has been removed from the top menu and instead implemented as a FAB (floating action button). The button has a bit of padding on the right to avoid overlapping the scrollbar.

I understand the branch name doesn't conform with this repos branch guidelines — I'll keep that in mind for the future.