### PR TITLE
Identity service

### DIFF
--- a/gridt/.gitignore
+++ b/gridt/.gitignore
@@ -28,6 +28,7 @@ plugins/
 plugins/android.json
 plugins/ios.json
 $RECYCLE.BIN/
+dist/
 
 .DS_Store
 Thumbs.db

--- a/gridt/src/app/core/api.service.spec.ts
+++ b/gridt/src/app/core/api.service.spec.ts
@@ -41,7 +41,7 @@ let mock_movements: Movement[] = [
     id: 112312983,
     name: "Flossing",
     short_description: "Floss every day",
-    description: "We floss every day because it is good for our theeth.",
+    description: "We floss every day because it is good for our teeth.",
     subscribed: true,
     interval: "daily"
   }
@@ -243,7 +243,7 @@ describe("ApiService when authentication is succesful", () => {
     const flossing_movement = {
       name: "Flossing",
       short_description: "Floss every day",
-      description: "We floss every day because it is good for our theeth.",
+      description: "We floss every day because it is good for our teeth.",
       subscribed: true,
       interval: "daily"
     } as Movement;

--- a/gridt/src/app/core/api.service.spec.ts
+++ b/gridt/src/app/core/api.service.spec.ts
@@ -129,7 +129,7 @@ describe("ApiService when authentication fails", () => {
 
   it('should fail to read identity from server when not logged in', () => {
     expect(
-      service.userIdentity$
+      service.userIdentity$()
     ).toBeObservable(cold("#", {}, "Can't authenticate: no credentials"));
   });
 
@@ -312,8 +312,8 @@ describe("ApiService when authentication is succesful", () => {
 
   it('should be able to retreive identity', () => {
     httpClientStub.get.and.returnValue(of(mock_identity[0]));
-    
-    expect(service.userIdentity$).toBeObservable(cold('(a|)', {a: mock_identity[0]}));
+
+    expect(service.userIdentity$()).toBeObservable(cold('(a|)', {a: mock_identity[0]}));
     expect(httpClientStub.get).toHaveBeenCalledWith(
       `${service.URL}/identity`,
       default_headers

--- a/gridt/src/app/core/api.service.spec.ts
+++ b/gridt/src/app/core/api.service.spec.ts
@@ -1,7 +1,6 @@
 import { Type } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
 import { HttpClient, HttpHeaders, HttpErrorResponse } from '@angular/common/http';
-import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
 
 import { cold } from 'jasmine-marbles';
 import { of, throwError } from "rxjs";
@@ -81,10 +80,7 @@ const default_headers = {
 };
 
 let service: ApiService;
-let auth: AuthService;
-let httpMock: HttpTestingController;
 let httpClientStub: jasmine.SpyObj<HttpClient>;
-let authServiceStub: jasmine.SpyObj<AuthService>;
 
 class authServiceStub_succes {
   isLoggedIn$ = of(true);
@@ -128,14 +124,14 @@ describe("ApiService when authentication fails", () => {
   });
 
   it('should fail to read identity from server when not logged in', () => {
-    expect(
-      service.userIdentity$()
-    ).toBeObservable(cold("#", {}, "Can't authenticate: no credentials"));
+    expect(service.userIdentity$())
+    .toBeObservable(cold("#", {}, "Can't authenticate: no credentials"));
   });
 
   it('should fail to update bio when not logged in', () => {
     let mock_bio = "My very first bio."
-    expect(service.changeBio$( mock_bio )).toBeObservable( cold('#', null, "Can't authenticate: no credentials"));
+    expect(service.changeBio$( mock_bio ))
+    .toBeObservable( cold('#', null, "Can't authenticate: no credentials"));
   });
 
   it('should fail to update password when not logged in', () => {

--- a/gridt/src/app/core/api.service.ts
+++ b/gridt/src/app/core/api.service.ts
@@ -233,14 +233,16 @@ export class ApiService {
   /**
   * Observable to obtain identity from server.
   */
-  public userIdentity$: Observable<Identity> = this.auth.readyAuthentication$.pipe(
-    flatMap((options) => this.http.get<Identity>(
-      `${this.URL}/identity`,
-      options
-    )),
-    catchError( this.handleBadAuth())
-  );
-
+  public userIdentity$(): Observable<Identity> {
+    return this.auth.readyAuthentication$.pipe(
+      flatMap((options) => this.http.get<Identity>(
+        `${this.URL}/identity`,
+        options
+      )),
+      catchError( this.handleBadAuth())
+    );
+  };
+  
   /**
   * Changes the biography of the user on the server.
   * @param bio the new bio that the user wants.

--- a/gridt/src/app/core/settings.service.spec.ts
+++ b/gridt/src/app/core/settings.service.spec.ts
@@ -64,7 +64,7 @@ describe("SettingsService when authentication fails", () => {
 
     secStoreStub = jasmine.createSpyObj(
       'SecureStorageService', {
-        'get$': of(JSON.stringify(mock_id[0])),
+        'get$': of(mock_id[0]),
         'set$': of(true),
         'clear$': of(true),
         'remove$': of(true)
@@ -121,7 +121,7 @@ describe("SettingsService when authentication is succesful", () => {
 
     secStoreStub = jasmine.createSpyObj(
       'SecureStorageService', {
-        'get$'    : of(JSON.stringify(mock_id[0])),
+        'get$'    : of(mock_id[0]),
         'set$'    : of(true),
         'clear$'  : of(true),
         'remove$' : of(true)
@@ -164,9 +164,7 @@ describe("SettingsService when authentication is succesful", () => {
     // Make sure any updates of the ID are reflected in the local storage.
     apiStub.userIdentity$.and.returnValue(of(mock_id[1]));
     service.updateIdentity();
-    expect(secStoreStub.set$).toHaveBeenCalledWith(
-      "identity", JSON.stringify(mock_id[1])
-    );
+    expect(secStoreStub.set$).toHaveBeenCalledWith("identity", mock_id[1]);
   });
 
   it("should not overwrite local id when local and server id are equal", () => {
@@ -182,9 +180,7 @@ describe("SettingsService when authentication is succesful", () => {
     apiStub.userIdentity$.and.returnValue(of(mock_id[3]));
     service.updateIdentity();
 
-    expect(secStoreStub.set$).toHaveBeenCalledWith(
-      "identity", JSON.stringify(mock_id[3])
-    );
+    expect(secStoreStub.set$).toHaveBeenCalledWith("identity", mock_id[3]);
   });
 
   it("should return empty identity when local and server are unavailable", () => {
@@ -200,7 +196,7 @@ describe("SettingsService when authentication is succesful", () => {
 
   it("should return local id when server and local id are equal", () => {
     //  Standard behaviour
-    secStoreStub.get$.and.returnValue(of(JSON.stringify(mock_id[0])));
+    secStoreStub.get$.and.returnValue(of(mock_id[0]));
     apiStub.userIdentity$.and.returnValue(of(mock_id[0]));
     service.updateIdentity();
     expect(service.userIdentity$).toBeObservable(cold('a',{a: mock_id[0]}));
@@ -243,7 +239,7 @@ describe("SettingsService when authentication is succesful", () => {
     });
 
     setLocalID.subscribe( (id) => secStoreStub.get$.and.returnValue(
-      of(JSON.stringify(id))
+      of(id)
     ));
 
     // When secStore is set, make sure it now returns right value upon get.
@@ -282,9 +278,7 @@ describe("SettingsService when authentication is succesful", () => {
     expect(service.setLocalIdentity$(mock_id[0])).toBeObservable(
       cold('(a|)',{a: true})
     );
-    expect(secStoreStub.set$).toHaveBeenCalledWith(
-      "identity", JSON.stringify(mock_id[0])
-    );
+    expect(secStoreStub.set$).toHaveBeenCalledWith("identity", mock_id[0]);
   });
 
   it("should be able to get the user's local Identity", () => {

--- a/gridt/src/app/core/settings.service.spec.ts
+++ b/gridt/src/app/core/settings.service.spec.ts
@@ -3,7 +3,8 @@ import { TestBed } from "@angular/core/testing";
 import { HttpClient, HttpHeaders, HttpErrorResponse } from '@angular/common/http';
 
 import { cold } from 'jasmine-marbles';
-import { of, throwError } from "rxjs";
+import { of, throwError, timer } from "rxjs";
+import { take, flatMap } from "rxjs/operators"
 
 import { AuthService } from './auth.service';
 import { ApiService } from './api.service';
@@ -93,7 +94,7 @@ describe("SettingsService when authentication fails", () => {
 
   it("should return an empty identity", () => {
     // spyOn(api, 'userIdentity$').and.returnValue(of(mock_id[0]));
-    api.userIdentity$ = of(mock_id[0]);
+    apiStub.userIdentity$.and.returnValue( of(mock_id[0]) );
     service.updateIdentity();
     expect(service.userIdentity$).toBeObservable(cold('a', {a: service.empty_identity}));
   });
@@ -113,7 +114,7 @@ describe("SettingsService when authentication fails", () => {
 
 describe("SettingsService when authentication is succesful", () => {
   beforeEach( () => {
-    apiStub = jasmine.createSpyObj('ApiService', ['userIdentity$']);
+    apiStub = jasmine.createSpyObj('api', {'userIdentity$': mock_id[0]});
 
     secStoreStub = jasmine.createSpyObj(
       'secStore', {'get$': of(mock_id[0]), 'set$': of(true), 'clear$': of(true), 'remove$': of(true)}
@@ -143,21 +144,21 @@ describe("SettingsService when authentication is succesful", () => {
 
   it("should return the local id when server id is unavailable", () => {
     // When there is no internet, the identity must remain available.
-    api.userIdentity$ = throwError("server unavailable");
+    apiStub.userIdentity$.and.returnValue( throwError("server unavailable") );
     service.updateIdentity();
     expect(service.userIdentity$).toBeObservable(cold('a',{a:mock_id[0]}));
   });
 
   it("should overwrite local id when server id differs", () => {
     // Make sure any updates of the ID are reflected in the local storage.
-    api.userIdentity$ = of(mock_id[1]);
+    apiStub.userIdentity$.and.returnValue( of(mock_id[1]) );
     service.updateIdentity();
     expect(secStoreStub.set$).toHaveBeenCalledWith("identity", mock_id[1]);
   });
 
   it("should not overwrite local id when local and server id are equal", () => {
     // Reduces number of calls
-    api.userIdentity$ = of(mock_id[0]);
+    apiStub.userIdentity$.and.returnValue( of(mock_id[0]) );
     service.updateIdentity();
     expect(secStoreStub.set$).not.toHaveBeenCalled();
   });
@@ -165,7 +166,7 @@ describe("SettingsService when authentication is succesful", () => {
   it("should set local id with server id when local id is unavailable", () => {
     // This happens for new users, because their localstorage has not been set yet.
     secStoreStub.get$.and.returnValue(throwError("Oops, localstore not set yet"));
-    api.userIdentity$ = of(mock_id[3]);
+    apiStub.userIdentity$.and.returnValue( of(mock_id[3]));
     service.updateIdentity();
     expect(secStoreStub.set$).toHaveBeenCalledWith("identity", mock_id[3]);
   });
@@ -173,7 +174,7 @@ describe("SettingsService when authentication is succesful", () => {
   it("should return empty identity when local and server are unavailable", () => {
     // Safety feature to make sure it doesn't prevent a page from loading.
     secStoreStub.get$.and.returnValue(throwError("Oops, localstore not set yet"));
-    api.userIdentity$ = throwError("Server not available");
+    apiStub.userIdentity$.and.returnValue( throwError("Server not available"));
     service.updateIdentity();
     expect(service.userIdentity$).toBeObservable(cold('a',{a:service.empty_identity}));
   });
@@ -181,9 +182,68 @@ describe("SettingsService when authentication is succesful", () => {
   it("should return local id when server and local id are equal", () => {
     //  Standard behaviour
     secStoreStub.get$.and.returnValue(of(mock_id[0]));
-    api.userIdentity$ = of(mock_id[0]);
+    apiStub.userIdentity$.and.returnValue( of(mock_id[0]) );
     service.updateIdentity();
     expect(service.userIdentity$).toBeObservable(cold('a',{a: mock_id[0]}))
+  });
+
+  it("should deal with many async calls", () => {
+    let mockIDs = {
+      a: mock_id[0],
+      b: mock_id[1],
+      c: mock_id[2],
+      e: service.empty_identity
+    };
+
+    /**
+     * Tests the async behavior of userIdentity$.
+     * - If both server and local identity are unavailable, emit empty ID.
+     *   [step 1]
+     * - When server ID is retreived, but local ID has not been set yet, store
+     *   server ID in local and emit local ID. [step 2]
+     * - When the server ID is different from local ID, overwrite local ID with
+     *   the server ID. Then emit local ID. [step 3,9]
+     * - If both the server and local identity agree, emit local ID. [step 4]
+     * - If the server is unavailable but local ID is available, emit local ID.
+     *   [step 5, 6]
+     * - Only when updateIdentity() function is called should the userIdentity$
+     *   change. [step 7,8]
+     */
+    let serverID            = cold('--abb-e--c--', mockIDs);
+    let setLocalID          = cold('-------a--b-', mockIDs);
+    let expectedUserID      = cold('e-abb-ba---c', mockIDs);
+    let userIDUpdates       = cold('q-qqq-qq---q', {q: true});
+
+    // Let server and local response be erronous at first
+    apiStub.userIdentity$.and.returnValue( throwError("Server not available") );
+    secStoreStub.get$.and.returnValue( throwError("Local storage not available"));
+
+    serverID.subscribe( (id) => {
+      apiStub.userIdentity$.and.returnValue( of(id) );
+    });
+
+    setLocalID.subscribe( (id) => secStoreStub.get$.and.returnValue( of(id) ));
+
+    // When secStore is set, make sure it now returns right value upon get.
+    secStoreStub.set$.and.callFake( (key: string, value: any) => {
+      secStoreStub.get$.and.returnValue( of(value) );
+      return of(true);
+    });
+
+    userIDUpdates.subscribe( () => service.updateIdentity() );
+
+    expect(service.userIdentity$).toBeObservable(expectedUserID);
+  });
+
+  it("should wait for the server to respond", () => {
+    apiStub.userIdentity$.and.returnValue(
+      timer(31).pipe(
+        take(1),
+        flatMap( () => of(mock_id[1]))
+      )
+    )
+    service.updateIdentity();
+    expect(service.userIdentity$).toBeObservable(cold('---a',{a:mock_id[1]}));
   });
 
   it("should be able to set the local user Identity", () => {

--- a/gridt/src/app/core/settings.service.spec.ts
+++ b/gridt/src/app/core/settings.service.spec.ts
@@ -93,23 +93,23 @@ describe("SettingsService when authentication fails", () => {
   });
 
   it("should return an empty identity", () => {
-    // spyOn(api, 'userIdentity$').and.returnValue(of(mock_id[0]));
-    apiStub.userIdentity$.and.returnValue(of(mock_id[0]));
+    apiStub.userIdentity$.and.returnValue( of(mock_id[0]) );
     service.updateIdentity();
     expect(service.userIdentity$)
-    .toBeObservable(cold('a', {a: service.empty_identity}));
+    .toBeObservable( cold('a', {a: service.empty_identity}) );
   });
 
   it("should fail to set local identity when not logged in", () => {
     let error = service.error_codes.SETIDFAIL + ": " + service.error_codes.NOTLOGGEDIN;
-    expect(service.setLocalIdentity$(mock_id[0])).toBeObservable(cold('#', null, error));
-    expect(secStoreStub.set$).not.toHaveBeenCalled();
+    expect( service.setLocalIdentity$( mock_id[0] ) )
+    .toBeObservable( cold( '#', null, error ) );
+    expect( secStoreStub.set$ ).not.toHaveBeenCalled();
   });
 
   it("should fail to get local identity when not logged in", () => {
     let error = service.error_codes.GETIDFAIL + ": " + service.error_codes.NOTLOGGEDIN;
-    expect(service.localIdentity$).toBeObservable(cold('#', null, error));
-    expect(secStoreStub.get$).not.toHaveBeenCalled();
+    expect( service.localIdentity$ ).toBeObservable( cold( '#', null, error ) );
+    expect( secStoreStub.get$ ).not.toHaveBeenCalled();
   });
 });
 
@@ -117,7 +117,7 @@ describe("SettingsService when authentication is succesful", () => {
   beforeEach( () => {
     jasmine.clock().install();
 
-    apiStub = jasmine.createSpyObj('api', {'userIdentity$': mock_id[0]});
+    apiStub = jasmine.createSpyObj( 'api', {'userIdentity$': mock_id[0]} );
 
     secStoreStub = jasmine.createSpyObj(
       'SecureStorageService', {
@@ -142,7 +142,7 @@ describe("SettingsService when authentication is succesful", () => {
       ]
     });
 
-    service = TestBed.get(SettingsService as Type<SettingsService>);
+    service = TestBed.get( SettingsService as Type<SettingsService> );
   });
 
   afterEach( () => {
@@ -150,56 +150,60 @@ describe("SettingsService when authentication is succesful", () => {
   })
 
   it("should be created", () => {
-    expect(service).toBeTruthy();
+    expect( service ).toBeTruthy();
   });
 
   it("should return the local id when server id is unavailable", () => {
     // When there is no internet, the identity must remain available.
-    apiStub.userIdentity$.and.returnValue(throwError("server unavailable"));
+    apiStub.userIdentity$.and.returnValue( throwError( "server unavailable" ) );
     service.updateIdentity();
-    expect(service.userIdentity$).toBeObservable(cold('a',{a:mock_id[0]}));
+    expect( service.userIdentity$ ).toBeObservable( cold( 'a',{a:mock_id[0]} ) );
   });
 
   it("should overwrite local id when server id differs", () => {
     // Make sure any updates of the ID are reflected in the local storage.
-    apiStub.userIdentity$.and.returnValue(of(mock_id[1]));
+    apiStub.userIdentity$.and.returnValue( of(mock_id[1]) );
     service.updateIdentity();
-    expect(secStoreStub.set$).toHaveBeenCalledWith("identity", mock_id[1]);
+    expect( secStoreStub.set$ ).toHaveBeenCalledWith( "identity", mock_id[1] );
   });
 
   it("should not overwrite local id when local and server id are equal", () => {
     // Reduces number of calls
-    apiStub.userIdentity$.and.returnValue(of(mock_id[0]));
+    apiStub.userIdentity$.and.returnValue( of(mock_id[0]) );
     service.updateIdentity();
-    expect(secStoreStub.set$).not.toHaveBeenCalled();
+    expect( secStoreStub.set$ ).not.toHaveBeenCalled();
   });
 
   it("should set local id with server id when local id is unavailable", () => {
     // This happens for new users, because their localstorage has not been set yet.
-    secStoreStub.get$.and.returnValue(throwError("Oops, localstore not set yet"));
-    apiStub.userIdentity$.and.returnValue(of(mock_id[3]));
+    secStoreStub.get$.and.returnValue(
+      throwError( "Oops, localstore not set yet" )
+    );
+    apiStub.userIdentity$.and.returnValue( of(mock_id[3]) );
     service.updateIdentity();
 
-    expect(secStoreStub.set$).toHaveBeenCalledWith("identity", mock_id[3]);
+    expect( secStoreStub.set$ ).toHaveBeenCalledWith( "identity", mock_id[3] );
   });
 
   it("should return empty identity when local and server are unavailable", () => {
     // Safety feature to make sure it doesn't prevent a page from loading.
     secStoreStub.get$
-    .and.returnValue(throwError("Oops, localstore not set yet"));
-    apiStub.userIdentity$.and.returnValue(throwError("Server not available"));
+    .and.returnValue( throwError( "Oops, localstore not set yet" ) );
+    apiStub.userIdentity$.and.returnValue(
+      throwError( "Server not available" )
+    );
     service.updateIdentity();
-    expect(service.userIdentity$).toBeObservable(
-      cold('a',{a:service.empty_identity})
+    expect( service.userIdentity$ ).toBeObservable(
+      cold( 'a',{a:service.empty_identity} )
     );
   });
 
   it("should return local id when server and local id are equal", () => {
     //  Standard behaviour
-    secStoreStub.get$.and.returnValue(of(mock_id[0]));
-    apiStub.userIdentity$.and.returnValue(of(mock_id[0]));
+    secStoreStub.get$.and.returnValue( of(mock_id[0]) );
+    apiStub.userIdentity$.and.returnValue( of(mock_id[0]) );
     service.updateIdentity();
-    expect(service.userIdentity$).toBeObservable(cold('a',{a: mock_id[0]}));
+    expect( service.userIdentity$ ).toBeObservable( cold( 'a',{a: mock_id[0]} ) );
   });
 
   it("should deal with many async calls", () => {
@@ -230,12 +234,12 @@ describe("SettingsService when authentication is succesful", () => {
     let userIDUpdates       = cold('q-qqq-qq---q', {q: true});
 
     // Let server and local response be erronous at first
-    apiStub.userIdentity$.and.returnValue(throwError("Server not available"));
+    apiStub.userIdentity$.and.returnValue( throwError( "Server not available" ) );
     secStoreStub.get$
-    .and.returnValue(throwError("Local storage not available"));
+    .and.returnValue( throwError( "Local storage not available" ) );
 
     serverID.subscribe( (id) => {
-      apiStub.userIdentity$.and.returnValue(of(id));
+      apiStub.userIdentity$.and.returnValue( of(id) );
     });
 
     setLocalID.subscribe( (id) => secStoreStub.get$.and.returnValue(
@@ -244,13 +248,13 @@ describe("SettingsService when authentication is succesful", () => {
 
     // When secStore is set, make sure it now returns right value upon get.
     secStoreStub.set$.and.callFake( (key: string, value: any) => {
-      secStoreStub.get$.and.returnValue(of(value));
+      secStoreStub.get$.and.returnValue( of(value) );
       return of(true);
     });
 
     userIDUpdates.subscribe( () => service.updateIdentity() );
 
-    expect(service.userIdentity$).toBeObservable(expectedUserID);
+    expect( service.userIdentity$ ).toBeObservable( expectedUserID );
   });
 
   it("should wait for the server to respond", fakeAsync(() => {
@@ -263,26 +267,27 @@ describe("SettingsService when authentication is succesful", () => {
 
     // When secStore is set, make sure it now returns right value upon get.
     secStoreStub.set$.and.callFake( (key: string, value: any) => {
-      secStoreStub.get$.and.returnValue(of(value));
+      secStoreStub.get$.and.returnValue( of(value) );
       return of(true);
     });
 
     service.updateIdentity();
     tick(15);
-    expect(service.userIdentity$).toBeObservable(cold('',{}));
+    expect( service.userIdentity$ ).toBeObservable( cold( '',{} ) );
     tick(30);
-    expect(service.userIdentity$).toBeObservable(cold('a',{a:mock_id[1]}));
+    expect( service.userIdentity$ ).toBeObservable( cold( 'a',{a:mock_id[1]} ) );
   }));
 
   it("should be able to set the local user Identity", () => {
-    expect(service.setLocalIdentity$(mock_id[0])).toBeObservable(
-      cold('(a|)',{a: true})
+    expect( service.setLocalIdentity$( mock_id[0] ) ).toBeObservable(
+      cold( '(a|)',{a: true} )
     );
-    expect(secStoreStub.set$).toHaveBeenCalledWith("identity", mock_id[0]);
+    expect( secStoreStub.set$ ).toHaveBeenCalledWith( "identity", mock_id[0] );
   });
 
   it("should be able to get the user's local Identity", () => {
-    expect(service.localIdentity$).toBeObservable(cold('(a|)',{a: mock_id[0]}));
-    expect(secStoreStub.get$).toHaveBeenCalledWith("identity");
+    expect( service.localIdentity$ )
+    .toBeObservable( cold( '(a|)',{a: mock_id[0]} ) );
+    expect( secStoreStub.get$ ).toHaveBeenCalledWith( "identity" );
   });
 });

--- a/gridt/src/app/core/settings.service.spec.ts
+++ b/gridt/src/app/core/settings.service.spec.ts
@@ -67,7 +67,12 @@ describe("SettingsService when authentication fails", () => {
     apiStub = jasmine.createSpyObj('ApiService', ['userIdentity$']);
 
     secStoreStub = jasmine.createSpyObj(
-      'secStore', {'get$': of(mock_id[0]), 'set$': of(true), 'clear$': of(true), 'remove$': of(true)}
+      'secStore', {
+        'get$': of(JSON.stringify(mock_id[0])),
+        'set$': of(true),
+        'clear$': of(true),
+        'remove$': of(true)
+      }
     );
 
     httpClientStub = jasmine.createSpyObj(
@@ -96,12 +101,16 @@ describe("SettingsService when authentication fails", () => {
     // spyOn(api, 'userIdentity$').and.returnValue(of(mock_id[0]));
     apiStub.userIdentity$.and.returnValue( of(mock_id[0]) );
     service.updateIdentity();
-    expect(service.userIdentity$).toBeObservable(cold('a', {a: service.empty_identity}));
+    expect(service.userIdentity$).toBeObservable(
+      cold('a', {a: service.empty_identity})
+    );
   });
 
   it("should fail to set local identity when not logged in", () => {
     let error = service.error_codes.SETIDFAIL + ": " + service.error_codes.NOTLOGGEDIN;
-    expect(service.setLocalIdentity$(mock_id[0])).toBeObservable(cold('#', null, error));
+    expect(service.setLocalIdentity$(mock_id[0])).toBeObservable(
+      cold('#', null, error)
+    );
     expect(secStoreStub.set$).not.toHaveBeenCalled();
   });
 
@@ -117,7 +126,12 @@ describe("SettingsService when authentication is succesful", () => {
     apiStub = jasmine.createSpyObj('api', {'userIdentity$': mock_id[0]});
 
     secStoreStub = jasmine.createSpyObj(
-      'secStore', {'get$': of(mock_id[0]), 'set$': of(true), 'clear$': of(true), 'remove$': of(true)}
+      'secStore', {
+        'get$': of(JSON.stringify(mock_id[0])),
+        'set$': of(true),
+        'clear$': of(true),
+        'remove$': of(true)
+      }
     );
 
     httpClientStub = jasmine.createSpyObj(
@@ -161,7 +175,9 @@ describe("SettingsService when authentication is succesful", () => {
     // Make sure any updates of the ID are reflected in the local storage.
     apiStub.userIdentity$.and.returnValue( of(mock_id[1]) );
     service.updateIdentity();
-    expect(secStoreStub.set$).toHaveBeenCalledWith("identity", mock_id[1]);
+    expect(secStoreStub.set$).toHaveBeenCalledWith(
+      "identity", JSON.stringify(mock_id[1])
+    );
   });
 
   it("should not overwrite local id when local and server id are equal", () => {
@@ -176,7 +192,9 @@ describe("SettingsService when authentication is succesful", () => {
     secStoreStub.get$.and.returnValue(throwError("Oops, localstore not set yet"));
     apiStub.userIdentity$.and.returnValue( of(mock_id[3]));
     service.updateIdentity();
-    expect(secStoreStub.set$).toHaveBeenCalledWith("identity", mock_id[3]);
+    expect(secStoreStub.set$).toHaveBeenCalledWith(
+      "identity", JSON.stringify(mock_id[3])
+    );
   });
 
   it("should return empty identity when local and server are unavailable", () => {
@@ -184,12 +202,14 @@ describe("SettingsService when authentication is succesful", () => {
     secStoreStub.get$.and.returnValue(throwError("Oops, localstore not set yet"));
     apiStub.userIdentity$.and.returnValue( throwError("Server not available"));
     service.updateIdentity();
-    expect(service.userIdentity$).toBeObservable(cold('a',{a:service.empty_identity}));
+    expect(service.userIdentity$).toBeObservable(
+      cold('a',{a:service.empty_identity})
+    );
   });
 
   it("should return local id when server and local id are equal", () => {
     //  Standard behaviour
-    secStoreStub.get$.and.returnValue(of(mock_id[0]));
+    secStoreStub.get$.and.returnValue(of(JSON.stringify(mock_id[0])));
     apiStub.userIdentity$.and.returnValue( of(mock_id[0]) );
     service.updateIdentity();
     expect(service.userIdentity$).toBeObservable(cold('a',{a: mock_id[0]}));
@@ -230,11 +250,13 @@ describe("SettingsService when authentication is succesful", () => {
       apiStub.userIdentity$.and.returnValue( of(id) );
     });
 
-    setLocalID.subscribe( (id) => secStoreStub.get$.and.returnValue( of(id) ));
+    setLocalID.subscribe( (id) => secStoreStub.get$.and.returnValue(
+      of(JSON.stringify(id))
+    ));
 
     // When secStore is set, make sure it now returns right value upon get.
     secStoreStub.set$.and.callFake( (key: string, value: any) => {
-      secStoreStub.get$.and.returnValue( of(value) );
+      secStoreStub.get$.and.returnValue( of( value) );
       return of(true);
     });
 
@@ -265,8 +287,12 @@ describe("SettingsService when authentication is succesful", () => {
   }));
 
   it("should be able to set the local user Identity", () => {
-    expect(service.setLocalIdentity$(mock_id[0])).toBeObservable(cold('(a|)',{a: true}));
-    expect(secStoreStub.set$).toHaveBeenCalledWith("identity", mock_id[0]);
+    expect(service.setLocalIdentity$(mock_id[0])).toBeObservable(
+      cold('(a|)',{a: true})
+    );
+    expect(secStoreStub.set$).toHaveBeenCalledWith(
+      "identity", JSON.stringify(mock_id[0])
+    );
   });
 
   it("should be able to get the user's local Identity", () => {

--- a/gridt/src/app/core/settings.service.ts
+++ b/gridt/src/app/core/settings.service.ts
@@ -24,7 +24,7 @@ export class SettingsService {
     SETIDFAIL: "Could not SET identity",
     NOTLOGGEDIN: "Not logged in",
     SECSTOREUNAVAILABLE: "Secure storage not available.",
-  }
+  };
 
   public empty_identity: Identity = {
     id: null,
@@ -32,7 +32,7 @@ export class SettingsService {
     bio: "",
     email: "",
     avatar: ""
-  }
+  };
 
   /**
   * Emits the last known identity
@@ -47,11 +47,15 @@ export class SettingsService {
 
   /**
   * This function updates the user identity.
-  * - When the server ID is different from the ID stored locally the local ID
-  *   is overwritten with the server ID. Then emit local ID.
-  * - If both the server and local identity agree, emit local ID.
-  * - If the server is unavailable, emit local ID.
   * - If both server and local identity are unavailable, emit empty ID.
+  * - When server ID is retreived, but local ID has not been set yet, store
+  *   server ID in local and emit local ID.
+  * - When the server ID is different from local ID, overwrite local ID with
+  *   the server ID. Then emit local ID.
+  * - If both the server and local identity agree, emit local ID.
+  * - If the server is unavailable but local ID is available, emit local ID.
+  * - Only when updateIdentity() function is called should the userIdentity$
+  *   change.
   *
   * - Makes sure all errors are caught such that this function always gives an
   *   output.
@@ -85,10 +89,9 @@ export class SettingsService {
       flatMap( () => this.localIdentity$ ),
       // If local identity unvailable emit empty ID.
       this.mapErrorToEmptyID,
-      tap( (id) => console.debug(`pre emit id = ${JSON.stringify(id)}`)),
       // make sure subscription completes and gives only one update.
       take(1)
-    ).subscribe( (id) => {console.log(`emitted id = ${JSON.stringify(id)}`); this._user_identity$.next(id)});
+    ).subscribe( (id) => this._user_identity$.next(id));
   };
 
   /**

--- a/gridt/src/app/core/settings.service.ts
+++ b/gridt/src/app/core/settings.service.ts
@@ -103,7 +103,7 @@ export class SettingsService {
     flatMap(() => this.secStore.get$("identity").pipe(
       catchError( () => throwError(this.error_codes.GETIDFAIL + ": " + this.error_codes.SECSTOREUNAVAILABLE))
     )),
-    flatMap( (id) => of<Identity>(id))
+    flatMap( (id) => of<Identity>(JSON.parse(id)))
   );
 
   /**
@@ -115,7 +115,7 @@ export class SettingsService {
       catchError( () => throwError(this.error_codes.SETIDFAIL + ": " + this.error_codes.NOTLOGGEDIN)),
       take(1), // Makes sure the observable completes
       tap( () => console.debug('Storing Identity in Localstorage')),
-      flatMap( () => this.secStore.set$("identity", identity).pipe(
+      flatMap( () => this.secStore.set$("identity", JSON.stringify(identity)).pipe(
           catchError(()=> throwError(this.error_codes.SETIDFAIL + ": " + this.error_codes.SECSTOREUNAVAILABLE))
       ))
     );

--- a/gridt/src/app/core/settings.service.ts
+++ b/gridt/src/app/core/settings.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from "@angular/core";
-import { Observable, pipe, throwError, of, iif } from "rxjs";
-import { flatMap, tap, map, catchError, pluck, mergeMap, take } from "rxjs/operators";
+import { Observable, pipe, throwError, of, iif, forkJoin, ReplaySubject } from "rxjs";
+import { flatMap, tap, catchError, take } from "rxjs/operators";
 
 import { Identity } from './models/identity.model';
 import { AuthService } from './auth.service';
+import { ApiService } from './api.service';
 import { SecureStorageService } from './secure-storage.service';
 
 @Injectable({
@@ -14,6 +15,7 @@ export class SettingsService {
 
   constructor (
     private auth: AuthService,
+    private api: ApiService,
     private secStore: SecureStorageService,
   ) {}
 
@@ -23,8 +25,82 @@ export class SettingsService {
     NOTLOGGEDIN: "Not logged in",
     SECSTOREUNAVAILABLE: "Secure storage not available.",
   }
+
+  public empty_identity: Identity = {
+    id: null,
+    username: "",
+    bio: "",
+    email: "",
+    avatar: ""
+  }
+
   /**
-   * Observable to obtain settings from secure storage
+  * Emits the last known identity
+  */
+  private _user_identity$ = new ReplaySubject<Identity>(1);
+
+  /**
+  * This Observable can be used in applications to display the latest known
+  * identity of the user.
+  */
+  public userIdentity$: Observable<Identity> = this._user_identity$.asObservable();
+
+  /**
+  * This function updates the user identity.
+  * - When the server ID is different from the ID stored locally the local ID
+  *   is overwritten with the server ID. Then emit local ID.
+  * - If both the server and local identity agree, emit local ID.
+  * - If the server is unavailable, emit local ID.
+  * - If both server and local identity are unavailable, emit empty ID.
+  *
+  * - Makes sure all errors are caught such that this function always gives an
+  *   output.
+  */
+  private mapErrorToEmptyID = pipe(
+    catchError( err => of(this.empty_identity))
+  );
+
+  private mapErrorToFalse = pipe(
+    catchError( err => {console.warn(err); return of(false);})
+  );
+
+  public updateIdentity(): void {
+    // Combine server and local id. Catch errors to make sure pipe runs.
+    forkJoin({
+      server: this.api.userIdentity$.pipe( this.mapErrorToEmptyID ),
+      local: this.localIdentity$.pipe( this.mapErrorToEmptyID )
+    }).pipe(
+      // Update local id when server id is different.
+      tap( (ids) => console.log(`init ids ${ids} \n = ${JSON.stringify(ids)}`)),
+      flatMap( (ids) => iif(
+        () => (ids.server==ids.local && ids.server != this.empty_identity), // && ids[0].id == ids[1].id
+        of(true),
+        this.setLocalIdentity$(ids.server[0])
+      )),
+      // Make sure any errors arising from setting local identity are
+      // transformed into a warning and continue.
+      this.mapErrorToFalse,
+      tap( (id) => console.log(`after iff ${id}`)),
+      // Emit local identity
+      flatMap( () => this.localIdentity$),
+      // If local identity unvailable emit empty ID.
+      this.mapErrorToEmptyID,
+      tap( (id) => console.log(`after flatmap ${JSON.stringify(id)}`) ),
+
+      // HELP NEEDED HERE!
+      // Somehow the type of the id is corrupted, don't know why. But hence
+      // For now I'm resetting the type.
+      flatMap( (id) => {
+        let idd: Identity = JSON.parse(JSON.stringify(id))
+        return of(idd);
+      }),
+      // make sure subscription completes and gives only one update.
+      take(1)
+    ).subscribe( (id) => {console.log(`emitted id = ${id}`); this._user_identity$.next(id)});
+  };
+
+  /**
+   * Observable to obtain identity from secure storage
    * If secure storage is empty, this returns an unavailable error
    */
   public localIdentity$: Observable<Identity> = this.auth.readyAuthentication$.pipe(
@@ -35,8 +111,8 @@ export class SettingsService {
   );
 
   /**
-   * Store settings in the secure storage.
-   * @param identity Settings to be stored.
+   * Store identity in the secure storage.
+   * @param identity Identity to be stored.
    */
   public setLocalIdentity$(identity: Identity): Observable<boolean> {
     return this.auth.readyAuthentication$.pipe(

--- a/gridt/src/app/core/settings.service.ts
+++ b/gridt/src/app/core/settings.service.ts
@@ -48,7 +48,7 @@ export class SettingsService {
   /**
   * This function updates the user identity.
   * - If both server and local identity are unavailable, emit empty ID.
-  * - When server ID is retreived, but local ID has not been set yet, store
+  * - When server ID is retrieved, but local ID has not been set yet, store
   *   server ID in local and emit local ID.
   * - When the server ID is different from local ID, overwrite local ID with
   *   the server ID. Then emit local ID.
@@ -78,7 +78,10 @@ export class SettingsService {
       // Update local id when server id is different.
       tap( (ids) => console.debug(`recieved server id = ${JSON.stringify(ids.server)} \n received local id = ${JSON.stringify(ids.local)}`)),
       flatMap( (ids) => iif(
-        () => ((JSON.stringify(ids.server)==JSON.stringify(ids.local)) || (JSON.stringify(ids.server) == JSON.stringify(this.empty_identity))), // && ids[0].id == ids[1].id
+        () => (
+          (JSON.stringify(ids.server)===JSON.stringify(ids.local))
+          || (JSON.stringify(ids.server) == JSON.stringify(this.empty_identity))
+        ),
         of(true),
         this.setLocalIdentity$(ids.server)
       )),
@@ -87,7 +90,7 @@ export class SettingsService {
       this.mapErrorToFalse,
       // Emit local identity
       flatMap( () => this.localIdentity$ ),
-      // If local identity unvailable emit empty ID.
+      // If local identity unavailable emit empty ID.
       this.mapErrorToEmptyID,
       // make sure subscription completes and gives only one update.
       take(1)
@@ -116,7 +119,7 @@ export class SettingsService {
       take(1), // Makes sure the observable completes
       tap( () => console.debug('Storing Identity in Localstorage')),
       flatMap( () => this.secStore.set$("identity", JSON.stringify(identity)).pipe(
-          catchError(()=> throwError(this.error_codes.SETIDFAIL + ": " + this.error_codes.SECSTOREUNAVAILABLE))
+          catchError( ()=> throwError(this.error_codes.SETIDFAIL + ": " + this.error_codes.SECSTOREUNAVAILABLE))
       ))
     );
   }

--- a/gridt/src/app/core/settings.service.ts
+++ b/gridt/src/app/core/settings.service.ts
@@ -106,7 +106,7 @@ export class SettingsService {
     flatMap(() => this.secStore.get$("identity").pipe(
       catchError( () => throwError(this.error_codes.GETIDFAIL + ": " + this.error_codes.SECSTOREUNAVAILABLE))
     )),
-    flatMap( (id) => of<Identity>(JSON.parse(id)))
+    flatMap( (id) => of<Identity>(id))
   );
 
   /**
@@ -118,7 +118,7 @@ export class SettingsService {
       catchError( () => throwError(this.error_codes.SETIDFAIL + ": " + this.error_codes.NOTLOGGEDIN)),
       take(1), // Makes sure the observable completes
       tap( () => console.debug('Storing Identity in Localstorage')),
-      flatMap( () => this.secStore.set$("identity", JSON.stringify(identity)).pipe(
+      flatMap( () => this.secStore.set$("identity", identity).pipe(
           catchError( ()=> throwError(this.error_codes.SETIDFAIL + ": " + this.error_codes.SECSTOREUNAVAILABLE))
       ))
     );

--- a/gridt/src/app/core/settings.service.ts
+++ b/gridt/src/app/core/settings.service.ts
@@ -61,12 +61,18 @@ export class SettingsService {
   *   output.
   */
   private mapErrorToEmptyID = pipe(
-    catchError( err => {console.warn(err); return of<Identity>(this.empty_identity);}),
-    flatMap( (id) => of(<Identity>(id)))
+    catchError( err => {
+      console.warn(err);
+      return of<Identity>(this.empty_identity);
+    }),
+    flatMap( (id) => of( <Identity>(id) ) )
   );
 
   private mapErrorToFalse = pipe(
-    catchError( err => {console.warn(err); return of<boolean>(false);})
+    catchError( err => {
+      console.warn(err);
+      return of<boolean>(false);
+    })
   );
 
   public updateIdentity(): void {
@@ -76,7 +82,7 @@ export class SettingsService {
       local: this.localIdentity$.pipe( this.mapErrorToEmptyID )
     }).pipe(
       // Update local id when server id is different.
-      tap( (ids) => console.debug(`recieved server id = ${JSON.stringify(ids.server)} \n received local id = ${JSON.stringify(ids.local)}`)),
+      tap( (ids) => console.debug(`recieved server id = ${JSON.stringify(ids.server)} \n received local id = ${JSON.stringify(ids.local)}`) ),
       flatMap( (ids) => iif(
         () => (
           (JSON.stringify(ids.server)===JSON.stringify(ids.local))
@@ -94,7 +100,7 @@ export class SettingsService {
       this.mapErrorToEmptyID,
       // make sure subscription completes and gives only one update.
       take(1)
-    ).subscribe( (id) => this._user_identity$.next(id));
+    ).subscribe( (id) => this._user_identity$.next(id) );
   };
 
   /**
@@ -102,11 +108,13 @@ export class SettingsService {
    * If secure storage is empty, this returns an unavailable error
    */
   public localIdentity$: Observable<Identity> = this.auth.readyAuthentication$.pipe(
-    catchError( () => throwError(this.error_codes.GETIDFAIL + ": " + this.error_codes.NOTLOGGEDIN)),
-    flatMap(() => this.secStore.get$("identity").pipe(
-      catchError( () => throwError(this.error_codes.GETIDFAIL + ": " + this.error_codes.SECSTOREUNAVAILABLE))
+    catchError( () => throwError(
+      this.error_codes.GETIDFAIL + ": " + this.error_codes.NOTLOGGEDIN
     )),
-    flatMap( (id) => of<Identity>(id))
+    flatMap( () => this.secStore.get$("identity").pipe(
+      catchError( () => throwError(this.error_codes.GETIDFAIL + ": " + this.error_codes.SECSTOREUNAVAILABLE) )
+    )),
+    flatMap( (id) => of<Identity>(id) )
   );
 
   /**
@@ -115,11 +123,11 @@ export class SettingsService {
    */
   public setLocalIdentity$(identity: Identity): Observable<boolean> {
     return this.auth.readyAuthentication$.pipe(
-      catchError( () => throwError(this.error_codes.SETIDFAIL + ": " + this.error_codes.NOTLOGGEDIN)),
+      catchError( () => throwError(this.error_codes.SETIDFAIL + ": " + this.error_codes.NOTLOGGEDIN) ),
       take(1), // Makes sure the observable completes
-      tap( () => console.debug('Storing Identity in Localstorage')),
+      tap( () => console.debug('Storing Identity in Localstorage') ),
       flatMap( () => this.secStore.set$("identity", identity).pipe(
-          catchError( ()=> throwError(this.error_codes.SETIDFAIL + ": " + this.error_codes.SECSTOREUNAVAILABLE))
+          catchError( ()=> throwError(this.error_codes.SETIDFAIL + ": " + this.error_codes.SECSTOREUNAVAILABLE) )
       ))
     );
   }


### PR DESCRIPTION
Fixes #149 

Within the settings service a userIdentity obervable is added which retrieves the Identity of the user from the server or from localstorage.

At the moment only one test is failing due to not implementing the jasmine timer correctly. This I'll fix shortly. But at this stage already a review can be useful.